### PR TITLE
Add/track and screen

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ android {
         textOutput 'stdout'
         disable 'InvalidPackage', 'GradleCompatible'
     }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -53,6 +57,12 @@ dependencies {
     testCompile 'org.robolectric:robolectric:3.3.1'
     testCompile 'org.assertj:assertj-core:1.7.1'
     testCompile 'org.mockito:mockito-core:1.10.19'
+
+    testCompile 'org.powermock:powermock:1.6.2'
+    testCompile 'org.powermock:powermock-module-junit4:1.6.2'
+    testCompile 'org.powermock:powermock-module-junit4-rule:1.6.2'
+    testCompile 'org.powermock:powermock-api-mockito:1.6.2'
+    testCompile 'org.powermock:powermock-classloading-xstream:1.6.2'
 }
 
 apply from: rootProject.file('gradle/attach-jar.gradle')

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -19,16 +19,23 @@ import com.segment.analytics.test.IdentifyPayloadBuilder;
 import com.segment.analytics.test.ScreenPayloadBuilder;
 import com.segment.analytics.test.TrackPayloadBuilder;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -44,18 +51,27 @@ import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 @RunWith(RobolectricTestRunner.class)
+@PrepareForTest(com.adobe.mobile.Analytics.class)
 @Config(constants = BuildConfig.class, sdk = 18, manifest = Config.NONE)
 public class AdobeTest {
 
-  @Mock Application application;
-  @Mock Analytics analytics;
+  @Rule
+  public PowerMockRule rule = new PowerMockRule();
+
+  private com.adobe.mobile.Analytics adobeAnalytics;
+  private AdobeIntegration integration;
 
   @Before
   public void setUp() {
+    adobeAnalytics = PowerMockito.mock(com.adobe.mobile.Analytics.class);
+    PowerMockito.mockStatic(com.adobe.mobile.Analytics.class);
+    integration = new AdobeIntegration(new ValueMap(), Logger.with(VERBOSE));
   }
 
   @Test
@@ -72,6 +88,44 @@ public class AdobeTest {
 
   @Test
   public void track() {
+    integration.events = new HashMap<>();
+    integration.events.put("Test Event", "myapp.testing.Testing");
+
+    integration.track(new TrackPayloadBuilder()
+      .event("Test Event")
+      .properties(new Properties())
+      .build());
+
+    verifyStatic();
+    adobeAnalytics.trackAction("myapp.testing.Testing", null);
+  }
+
+  @Test
+  public void trackWithoutMappedName() {
+    integration.track(new TrackPayloadBuilder()
+        .event("Test Event")
+        .properties(new Properties())
+        .build());
+
+    verifyZeroInteractions(adobeAnalytics);
+  }
+
+
+  @Test
+  public void trackEcommerce() {
+    integration.track(new TrackPayloadBuilder()
+      .event("Order Completed")
+      .properties(new Properties()
+        .putOrderId("123")
+      )
+      .build());
+
+    Map<String, Object> contextData = new HashMap<>();
+    contextData.put("purchaseid", "123");
+    contextData.put("orderId", "123");
+
+    verifyStatic();
+    adobeAnalytics.trackAction("purchase", contextData);
   }
 
   @Test
@@ -80,6 +134,18 @@ public class AdobeTest {
 
   @Test
   public void screen() {
+    integration.screen(new ScreenPayloadBuilder()
+        .name("Viewed Home Screen")
+        .properties(new Properties()
+            .putValue("userLoggedIn", true)
+        )
+        .build());
+
+    Map<String, Object> contextData = new HashMap<>();
+    contextData.put("userLoggedIn", true);
+
+    verifyStatic();
+    adobeAnalytics.trackState("Viewed Home Screen", contextData);
   }
 
   @Test


### PR DESCRIPTION
The PR includes two branches:

- add/track-and-screen
- add/ecommerce (merged into add/track-and-screen)

Adds core support for:
- screen
- track
-- mapping event names (events setting), eVars and lVars
- ecommerce tracking

Adds tests:
- track standard event with mapped event name
- track standard event without mapped event name (no interaction expected)
- track an ecommerce evenet
- track a screen event
- these tests all pass locally

There are probably a number of mistakes, but submitting PR now in the interest of iterating quickly.