### PR TITLE
Set up tests and add flush test to verify it works

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ android {
         textOutput 'stdout'
         disable 'InvalidPackage', 'GradleCompatible'
     }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -53,6 +57,12 @@ dependencies {
     testCompile 'org.robolectric:robolectric:3.3.1'
     testCompile 'org.assertj:assertj-core:1.7.1'
     testCompile 'org.mockito:mockito-core:1.10.19'
+
+    testCompile 'org.powermock:powermock:1.6.2'
+    testCompile 'org.powermock:powermock-module-junit4:1.6.2'
+    testCompile 'org.powermock:powermock-module-junit4-rule:1.6.2'
+    testCompile 'org.powermock:powermock-api-mockito:1.6.2'
+    testCompile 'org.powermock:powermock-classloading-xstream:1.6.2'
 }
 
 apply from: rootProject.file('gradle/attach-jar.gradle')

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -25,10 +25,15 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -46,16 +51,20 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
 @RunWith(RobolectricTestRunner.class)
+@PrepareForTest(com.adobe.mobile.Analytics.class)
 @Config(constants = BuildConfig.class, sdk = 18, manifest = Config.NONE)
 public class AdobeTest {
 
-  @Mock Application application;
-  @Mock Analytics analytics;
+  @Rule public PowerMockRule rule = new PowerMockRule();
+  private AdobeIntegration integration;
 
   @Before
   public void setUp() {
+    PowerMockito.mockStatic(com.adobe.mobile.Analytics.class);
+    integration = new AdobeIntegration(new ValueMap(), Logger.with(VERBOSE));
   }
 
   @Test
@@ -88,6 +97,9 @@ public class AdobeTest {
 
   @Test
   public void flush() {
+    integration.flush();
+    verifyStatic();
+    com.adobe.mobile.Analytics.sendQueuedHits();
   }
 
   @Test


### PR DESCRIPTION
- Uses add/flush branch as a base
- Sets up tests
- Adds unit test for `flush` method to ensure that at least one test passes
- `testOptions` block in the build.gradle file resolves this error: "java.lang.RuntimeException: Method v in android.util.Log not mocked. See http://g.co/androidstudio/not-mocked for details."