### PR TITLE
Add/video ad events

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -89,7 +89,9 @@ public class AdobeIntegration extends Integration<Void> {
               "Video Playback Buffer Started",
               "Video Playback Buffer Completed",
               "Video Playback Seek Started",
-              "Video Playback Seek Completed"));
+              "Video Playback Seek Completed",
+              "Video Ad Started",
+              "Video Ad Completed"));
 
   private static final Map<String, String> VIDEO_METADATA_MAP = getStandardVideoMetadataMap();
 
@@ -512,6 +514,21 @@ public class AdobeIntegration extends Integration<Void> {
 
       case "Video Playback Seek Completed":
         heartbeat.trackEvent(MediaHeartbeat.Event.SeekComplete, null, null);
+        break;
+
+      case "Video Ad Started":
+        MediaObject adInfo =
+            MediaHeartbeat.createAdObject(
+                properties.getString("title"),
+                properties.getString("assetId"),
+                properties.getLong("position", 0),
+                properties.getDouble("totalLength", 0));
+
+        heartbeat.trackEvent(MediaHeartbeat.Event.AdStart, adInfo, properties.toStringMap());
+        break;
+
+      case "Video Ad Completed":
+        heartbeat.trackEvent(MediaHeartbeat.Event.AdComplete, null, null);
         break;
     }
   }

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -618,6 +618,68 @@ public class AdobeTest {
   }
 
   @Test
+  public void trackVideoAdStarted() {
+    Properties properties = new Properties();
+    properties.putValue("title", "You Win or You Die");
+    properties.putValue("sessionId", "123");
+    properties.putValue("totalLength", 100D);
+    properties.putValue("assetId", "123");
+    properties.putValue("program", "Game of Thrones");
+    properties.putValue("season", "1");
+    properties.putValue("episode", "7");
+    properties.putValue("genre", "fantasy");
+    properties.putValue("channel", "HBO");
+    properties.putValue("airdate", "2011");
+    properties.putValue("position", 100);
+    properties.putValue("livestream", false);
+    properties.putValue("random metadata", "something super random");
+
+
+    integration.videoHeartbeatEnabled = true;
+    integration.track(new TrackPayload.Builder()
+        .userId("123")
+        .event("Video Ad Started")
+        .properties(new Properties()
+            .putValue("title", "You Win or You Die")
+            .putValue("sessionId", "123")
+            .putValue("totalLength", 100D)
+            .putValue("assetId", "123")
+            .putValue("program", "Game of Thrones")
+            .putValue("season", "1")
+            .putValue("episode", "7")
+            .putValue("genre", "fantasy")
+            .putValue("channel", "HBO")
+            .putValue("airdate", "2011")
+            .putValue("position", 100)
+            .putValue("livestream", false)
+            .putValue("random metadata", "something super random"))
+        .build()
+    );
+
+    // create a media object; values can be null
+    MediaObject mediaInfo = MediaHeartbeat.createAdObject(
+        "You Win or You Die",
+        "123",
+        100L,
+        100D
+    );
+
+    verify(heartbeat).trackEvent(eq(MediaHeartbeat.Event.AdStart), isEqualToComparingFieldByFieldRecursively(mediaInfo),
+        eq(properties.toStringMap()));
+  }
+
+  @Test
+  public void trackVideoAdComplete() {
+    integration.track(new TrackPayload.Builder()
+        .userId("123")
+        .event("Video Ad Completed")
+        .build()
+    );
+
+    verify(heartbeat).trackEvent(MediaHeartbeat.Event.AdComplete, null, null);
+  }
+
+  @Test
   public void identify() {
     integration.identify(new IdentifyPayload.Builder()
         .userId("123")


### PR DESCRIPTION
- Adds ad event mapping for "Video Ad Started" and "Video Ad Completed" 
- This implementation may change  slight as we figure out if/how we should map Adobe's additional "Ad Break Started" and "Ad Break Completed" events