### PR TITLE
Rename provider interface and media delegate for clarity

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -44,7 +44,7 @@ public class AdobeIntegration extends Integration<Void> {
         @Override
         public Integration<?> create(ValueMap settings, com.segment.analytics.Analytics analytics) {
           Logger logger = analytics.logger(ADOBE_KEY);
-          return new AdobeIntegration(settings, analytics, logger, Provider.REAL);
+          return new AdobeIntegration(settings, analytics, logger, HeartbeatFactory.REAL);
         }
 
         @Override
@@ -108,7 +108,7 @@ public class AdobeIntegration extends Integration<Void> {
       ValueMap settings,
       com.segment.analytics.Analytics analytics,
       Logger logger,
-      Provider provider) {
+      HeartbeatFactory heartbeatFactory) {
     this.eventsV2 = settings.getValueMap("eventsV2");
     this.contextValues = settings.getValueMap("contextValues");
     this.productIdentifier = settings.getString("productIdentifier");
@@ -137,13 +137,13 @@ public class AdobeIntegration extends Integration<Void> {
       config.ssl = settings.getBoolean("heartbeatEnableSsl", false);
       config.debugLogging = adobeLogLevel;
 
-      heartbeat = provider.get(new NoOpDelegate(), config);
+      heartbeat = heartbeatFactory.get(new PlaybackDelegate(), config);
     }
   }
 
-  static class NoOpDelegate implements MediaHeartbeatDelegate {
+  static class PlaybackDelegate implements MediaHeartbeatDelegate {
 
-    private NoOpDelegate() {}
+    private PlaybackDelegate() {}
 
     @Override
     public MediaObject getQoSObject() {
@@ -156,12 +156,12 @@ public class AdobeIntegration extends Integration<Void> {
     }
   }
 
-  interface Provider {
+  interface HeartbeatFactory {
 
     MediaHeartbeat get(MediaHeartbeatDelegate delegate, MediaHeartbeatConfig config);
 
-    Provider REAL =
-        new Provider() {
+    HeartbeatFactory REAL =
+        new HeartbeatFactory() {
           @Override
           public MediaHeartbeat get(MediaHeartbeatDelegate delegate, MediaHeartbeatConfig config) {
             return new MediaHeartbeat(delegate, config);

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -57,7 +57,7 @@ public class AdobeTest {
   private @Mock MediaHeartbeat heartbeat;
   private @Mock com.segment.analytics.Analytics analytics;
   private @Mock Application context;
-  private AdobeIntegration.Provider mockProvider = new AdobeIntegration.Provider() {
+  private AdobeIntegration.HeartbeatFactory mockHeartbeatFactory = new AdobeIntegration.HeartbeatFactory() {
     @Override
     public MediaHeartbeat get(MediaHeartbeatDelegate delegate, MediaHeartbeatConfig config) {
       return heartbeat;
@@ -71,7 +71,7 @@ public class AdobeTest {
     PowerMockito.mockStatic(Analytics.class);
     when(analytics.getApplication()).thenReturn(context);
     integration = new AdobeIntegration(new ValueMap()
-        .putValue("videoHeartbeatEnabled", true), analytics, Logger.with(NONE), mockProvider);
+        .putValue("videoHeartbeatEnabled", true), analytics, Logger.with(NONE), mockHeartbeatFactory);
   }
 
   @Test
@@ -89,7 +89,7 @@ public class AdobeTest {
         .putValue("adobeVerboseLogging", true),
       analytics,
       Logger.with(VERBOSE),
-        mockProvider);
+        mockHeartbeatFactory);
 
     verifyStatic();
     Config.setDebugLogging(true);
@@ -110,7 +110,7 @@ public class AdobeTest {
         .putValue("heartbeatEnableSsl", true),
         analytics,
         Logger.with(VERBOSE),
-        mockProvider);
+        mockHeartbeatFactory);
 
     verifyStatic();
     Config.setDebugLogging(true);


### PR DESCRIPTION
- Changes "Provider" interface name to "HeartbeatFactory"
- Changes "NoOpDelegate" implementation to name to "PlaybackDelegate"
- Updates associated tests to reflect name changes