### PR TITLE
Add/initial playhead tracker implementation

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -534,6 +534,7 @@ public class AdobeIntegration extends Integration<Void> {
         break;
 
       case "Video Playback Buffer Completed":
+        playbackDelegate.unPausePlayhead();
         heartbeat.trackEvent(MediaHeartbeat.Event.BufferComplete, null, null);
         break;
 

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -136,6 +136,12 @@ public class AdobeIntegration extends Integration<Void> {
   }
 
   static class PlaybackDelegate implements MediaHeartbeatDelegate {
+    long initialTime;
+    long playheadPosition;
+    long pausedPlayheadPosition;
+    long pauseStartedTime;
+    long offset = 0;
+    boolean isPaused = false;
 
     private PlaybackDelegate() {}
 
@@ -146,7 +152,37 @@ public class AdobeIntegration extends Integration<Void> {
 
     @Override
     public Double getCurrentPlaybackTime() {
-      return null;
+      if (initialTime == 0) {
+        setInitialTime();
+      }
+      if (!isPaused) {
+        incrementPlayheadPosition();
+        return (double) playheadPosition;
+      }
+      return (double) pausedPlayheadPosition;
+    }
+
+    private void setInitialTime() {
+      this.initialTime = System.currentTimeMillis();
+    }
+
+    private void incrementPlayheadPosition() {
+      this.playheadPosition = ((System.currentTimeMillis() - initialTime) / 1000) - offset;
+    }
+
+    private void pausePlayhead() {
+      this.pausedPlayheadPosition = playheadPosition;
+      this.pauseStartedTime = System.currentTimeMillis();
+      this.isPaused = true;
+    }
+
+    private void unPausePlayhead() {
+      if (offset == 0) {
+        offset = (System.currentTimeMillis() - pauseStartedTime) / 1000;
+      } else {
+        offset = offset + (System.currentTimeMillis() - pauseStartedTime) / 1000;
+      }
+      isPaused = false;
     }
   }
 

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -100,6 +100,7 @@ public class AdobeIntegration extends Integration<Void> {
   private final Logger logger;
   private MediaHeartbeat heartbeat;
   private HeartbeatFactory heartbeatFactory;
+  PlaybackDelegate playbackDelegate;
   final boolean adobeLogLevel;
   final String heartbeatTrackingServer;
   final String packageName;
@@ -465,7 +466,8 @@ public class AdobeIntegration extends Integration<Void> {
         config.ssl = ssl;
         config.debugLogging = adobeLogLevel;
 
-        heartbeat = heartbeatFactory.get(new PlaybackDelegate(), config);
+        this.playbackDelegate = new PlaybackDelegate();
+        heartbeat = heartbeatFactory.get(playbackDelegate, config);
 
         Map<String, String> standardVideoMetadata = new HashMap<>();
         Properties videoProperties = mapStandardVideoMetadata(properties, standardVideoMetadata);
@@ -488,10 +490,12 @@ public class AdobeIntegration extends Integration<Void> {
         break;
 
       case "Video Playback Paused":
+        playbackDelegate.pausePlayhead();
         heartbeat.trackPause();
         break;
 
       case "Video Playback Resumed":
+        playbackDelegate.unPausePlayhead();
         heartbeat.trackPlay();
         break;
 
@@ -525,6 +529,7 @@ public class AdobeIntegration extends Integration<Void> {
         break;
 
       case "Video Playback Buffer Started":
+        playbackDelegate.pausePlayhead();
         heartbeat.trackEvent(MediaHeartbeat.Event.BufferStart, null, null);
         break;
 
@@ -533,6 +538,7 @@ public class AdobeIntegration extends Integration<Void> {
         break;
 
       case "Video Playback Seek Started":
+        playbackDelegate.pausePlayhead();
         heartbeat.trackEvent(MediaHeartbeat.Event.SeekStart, null, null);
         break;
 

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -199,7 +199,7 @@ public class AdobeIntegration extends Integration<Void> {
      * at which the video was paused in `pauseStartedTime`. Sets `isPaused` to true so
      * `getCurrentPlaybackTime()` knows the video is in a paused state.
      */
-    private void pausePlayhead() {
+    public void pausePlayhead() {
       this.pausedPlayheadPosition.set(playheadPosition.get());
       this.pauseStartedTime = System.currentTimeMillis();
       this.isPaused = true;
@@ -217,7 +217,7 @@ public class AdobeIntegration extends Integration<Void> {
      *
      * <p>offset = originalOffset + (currentSystemTime - timePlayerWasPaused)
      */
-    private void unPausePlayhead() {
+    public void unPausePlayhead() {
       if (offset == 0) {
         offset = (System.currentTimeMillis() - pauseStartedTime) / 1000;
       } else {

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -143,16 +143,15 @@ public class AdobeIntegration extends Integration<Void> {
   static class PlaybackDelegate implements MediaHeartbeatDelegate {
     /**
      * The system time in millis at which the current instance of PlaybackDelegate was instantiated
-     * *
      */
     final long initialTime;
-    /** The current playhead position in seconds * */
+    /** The current playhead position in seconds */
     long playheadPosition;
-    /** The position of the playhead in seconds when the video was paused * */
+    /** The position of the playhead in seconds when the video was paused */
     long pausedPlayheadPosition;
-    /** The system time in millis at which pausePlayhead() was invoked * */
+    /** The system time in millis at which pausePlayhead() was invoked */
     long pauseStartedTime;
-    /** The total time in seconds a video has been in a paused state during a video session * */
+    /** The total time in seconds a video has been in a paused state during a video session */
     long offset = 0;
 
     boolean isPaused = false;

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -141,13 +141,13 @@ public class AdobeIntegration extends Integration<Void> {
    * to write logic and returns the position of a video playhead during a video session.
    */
   static class PlaybackDelegate implements MediaHeartbeatDelegate {
-    /** The system time at which the current instance of PlaybackDelegate was instantiated * */
+    /** The system time in millis at which the current instance of PlaybackDelegate was instantiated * */
     final long initialTime;
-    /** The current playhead position * */
+    /** The current playhead position in seconds * */
     long playheadPosition;
-    /** The position of the playhead when the video is paused * */
+    /** The position of the playhead in seconds when the video was paused * */
     long pausedPlayheadPosition;
-    /** The system time at which pausePlayhead() was invoked * */
+    /** The system time in millis at which pausePlayhead() was invoked * */
     long pauseStartedTime;
     /** The total time in seconds a video has been in a paused state during a video session * */
     long offset = 0;

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.segment.analytics.internal.Utils.isNullOrEmpty;
 
@@ -138,20 +139,19 @@ public class AdobeIntegration extends Integration<Void> {
 
   /*
    * PlaybackDelegate implements Adobe's MediaHeartbeatDelegate interface. This implementation allows us
-   * to write logic and returns the position of a video playhead during a video session.
+   * to define logic that returns the position of a video playhead during a video session.
    */
   static class PlaybackDelegate implements MediaHeartbeatDelegate {
     /** The system time at which the current instance of PlaybackDelegate was instantiated * */
     final long initialTime;
-    /** The current playhead position * */
-    long playheadPosition;
-    /** The position of the playhead when the video is paused * */
-    long pausedPlayheadPosition;
+    /** The current playhead position; atomic in case this value is accessed by multiple threads * */
+    AtomicLong playheadPosition = new AtomicLong();
+    /** The position of the playhead when the video is paused; atomic in case this value is accessed by multiple threads * */
+    AtomicLong pausedPlayheadPosition = new AtomicLong();
     /** The system time at which pausePlayhead() was invoked * */
     long pauseStartedTime;
     /** The total time in seconds a video has been in a paused state during a video session * */
     long offset = 0;
-
     boolean isPaused = false;
 
     private PlaybackDelegate() {
@@ -173,9 +173,9 @@ public class AdobeIntegration extends Integration<Void> {
     public Double getCurrentPlaybackTime() {
       if (!isPaused) {
         incrementPlayheadPosition();
-        return (double) playheadPosition;
+        return (double) playheadPosition.get();
       }
-      return (double) pausedPlayheadPosition;
+      return (double) pausedPlayheadPosition.get();
     }
 
     /**
@@ -185,7 +185,7 @@ public class AdobeIntegration extends Integration<Void> {
      * <p>(currentSystemTime - videoSessionStartTime) - offset
      */
     private void incrementPlayheadPosition() {
-      this.playheadPosition = ((System.currentTimeMillis() - initialTime) / 1000) - offset;
+      this.playheadPosition.set(((System.currentTimeMillis() - initialTime) / 1000) - offset);
     }
 
     /**
@@ -194,7 +194,7 @@ public class AdobeIntegration extends Integration<Void> {
      * `getCurrentPlaybackTime()` knows the video is in a paused state.
      */
     private void pausePlayhead() {
-      this.pausedPlayheadPosition = playheadPosition;
+      this.pausedPlayheadPosition.set(playheadPosition.get());
       this.pauseStartedTime = System.currentTimeMillis();
       this.isPaused = true;
     }

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -144,14 +144,20 @@ public class AdobeIntegration extends Integration<Void> {
   static class PlaybackDelegate implements MediaHeartbeatDelegate {
     /** The system time at which the current instance of PlaybackDelegate was instantiated * */
     final long initialTime;
-    /** The current playhead position; atomic in case this value is accessed by multiple threads * */
+    /**
+     * The current playhead position; atomic in case this value is accessed by multiple threads *
+     */
     AtomicLong playheadPosition = new AtomicLong();
-    /** The position of the playhead when the video is paused; atomic in case this value is accessed by multiple threads * */
+    /**
+     * The position of the playhead when the video is paused; atomic in case this value is accessed
+     * by multiple threads *
+     */
     AtomicLong pausedPlayheadPosition = new AtomicLong();
     /** The system time at which pausePlayhead() was invoked * */
     long pauseStartedTime;
     /** The total time in seconds a video has been in a paused state during a video session * */
     long offset = 0;
+
     boolean isPaused = false;
 
     private PlaybackDelegate() {

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -141,7 +141,10 @@ public class AdobeIntegration extends Integration<Void> {
    * to write logic and returns the position of a video playhead during a video session.
    */
   static class PlaybackDelegate implements MediaHeartbeatDelegate {
-    /** The system time in millis at which the current instance of PlaybackDelegate was instantiated * */
+    /**
+     * The system time in millis at which the current instance of PlaybackDelegate was instantiated
+     * *
+     */
     final long initialTime;
     /** The current playhead position in seconds * */
     long playheadPosition;

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -144,7 +144,9 @@ public class AdobeIntegration extends Integration<Void> {
     long offset = 0;
     boolean isPaused = false;
 
-    private PlaybackDelegate() {}
+    private PlaybackDelegate() {
+      this.initialTime = System.currentTimeMillis();
+    }
 
     @Override
     public MediaObject getQoSObject() {
@@ -153,18 +155,11 @@ public class AdobeIntegration extends Integration<Void> {
 
     @Override
     public Double getCurrentPlaybackTime() {
-      if (initialTime == 0) {
-        setInitialTime();
-      }
       if (!isPaused) {
         incrementPlayheadPosition();
         return (double) playheadPosition;
       }
       return (double) pausedPlayheadPosition;
-    }
-
-    private void setInitialTime() {
-      this.initialTime = System.currentTimeMillis();
     }
 
     private void incrementPlayheadPosition() {

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -154,7 +154,7 @@ public class AdobeIntegration extends Integration<Void> {
 
     boolean isPaused = false;
 
-    private PlaybackDelegate() {
+    public PlaybackDelegate() {
       this.initialTime = System.currentTimeMillis();
     }
 

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static com.segment.analytics.internal.Utils.isNullOrEmpty;
 
@@ -139,20 +138,15 @@ public class AdobeIntegration extends Integration<Void> {
 
   /*
    * PlaybackDelegate implements Adobe's MediaHeartbeatDelegate interface. This implementation allows us
-   * to define logic that returns the position of a video playhead during a video session.
+   * to write logic and returns the position of a video playhead during a video session.
    */
   static class PlaybackDelegate implements MediaHeartbeatDelegate {
     /** The system time at which the current instance of PlaybackDelegate was instantiated * */
     final long initialTime;
-    /**
-     * The current playhead position; atomic in case this value is accessed by multiple threads *
-     */
-    AtomicLong playheadPosition = new AtomicLong();
-    /**
-     * The position of the playhead when the video is paused; atomic in case this value is accessed
-     * by multiple threads *
-     */
-    AtomicLong pausedPlayheadPosition = new AtomicLong();
+    /** The current playhead position * */
+    long playheadPosition;
+    /** The position of the playhead when the video is paused * */
+    long pausedPlayheadPosition;
     /** The system time at which pausePlayhead() was invoked * */
     long pauseStartedTime;
     /** The total time in seconds a video has been in a paused state during a video session * */
@@ -179,9 +173,9 @@ public class AdobeIntegration extends Integration<Void> {
     public Double getCurrentPlaybackTime() {
       if (!isPaused) {
         incrementPlayheadPosition();
-        return (double) playheadPosition.get();
+        return (double) playheadPosition;
       }
-      return (double) pausedPlayheadPosition.get();
+      return (double) pausedPlayheadPosition;
     }
 
     /**
@@ -191,7 +185,7 @@ public class AdobeIntegration extends Integration<Void> {
      * <p>(currentSystemTime - videoSessionStartTime) - offset
      */
     private void incrementPlayheadPosition() {
-      this.playheadPosition.set(((System.currentTimeMillis() - initialTime) / 1000) - offset);
+      this.playheadPosition = ((System.currentTimeMillis() - initialTime) / 1000) - offset;
     }
 
     /**
@@ -200,7 +194,7 @@ public class AdobeIntegration extends Integration<Void> {
      * `getCurrentPlaybackTime()` knows the video is in a paused state.
      */
     public void pausePlayhead() {
-      this.pausedPlayheadPosition.set(playheadPosition.get());
+      this.pausedPlayheadPosition = playheadPosition;
       this.pauseStartedTime = System.currentTimeMillis();
       this.isPaused = true;
     }

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -411,44 +411,27 @@ public class AdobeTest {
   }
 
   @Test
-  public void videoPlaybackDelegatePlay() {
-    newVideoSession();
-    try {
-      Thread.sleep(2000);
-    }
-    catch(InterruptedException e) {
-    }
+  public void videoPlaybackDelegatePlay() throws Exception {
+    integration.playbackDelegate = new AdobeIntegration.PlaybackDelegate();
+    Thread.sleep(2000);
     assertTrue(integration.playbackDelegate.getCurrentPlaybackTime().equals(2.0));
   }
 
   @Test
-  public void videoPlaybackDelegatePaused() {
-    newVideoSession();
+  public void videoPlaybackDelegatePaused() throws Exception {
+    integration.playbackDelegate = new AdobeIntegration.PlaybackDelegate();
     integration.playbackDelegate.pausePlayhead();
     Double firstPlayheadPosition = integration.playbackDelegate.getCurrentPlaybackTime();
-    try {
-      Thread.sleep(2000);
-    }
-    catch(InterruptedException e) {
-    }
+    Thread.sleep(2000);
     assertTrue(integration.playbackDelegate.getCurrentPlaybackTime().equals(firstPlayheadPosition));
   }
 
   @Test
-  public void videoPlaybackDelegatePlayAndPause() {
-    newVideoSession();
+  public void videoPlaybackDelegatePlayAndPause() throws Exception {
+    integration.playbackDelegate = new AdobeIntegration.PlaybackDelegate();
     integration.playbackDelegate.pausePlayhead();
-    try {
-      Thread.sleep(1000);
-    }
-    catch(InterruptedException e) {
-    }
-    integration.playbackDelegate.unPausePlayhead();
-    try {
-      Thread.sleep(3000);
-    }
-    catch(InterruptedException e) {
-    }
+    Thread.sleep(1000);
+    integration.playbackDelegate.unPausePlayhead();Thread.sleep(3000);
     assertTrue(integration.playbackDelegate.getCurrentPlaybackTime().equals(3.0));
   }
 

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -465,12 +465,14 @@ public class AdobeTest {
 
     verify(heartbeat).trackSessionStart(isEqualToComparingFieldByFieldRecursively(mediaInfo),
         eq(videoMetadata));
+    assertTrue(integration.playbackDelegate != null);
   }
 
   @Test
   public void trackVideoPlaybackPaused() {
     newVideoSession();
     heartbeatTestFixture("Video Playback Paused");
+    assertTrue(integration.playbackDelegate.isPaused);
     verify(heartbeat).trackPause();
   }
 
@@ -478,6 +480,7 @@ public class AdobeTest {
   public void trackVideoPlaybackResumed() {
     newVideoSession();
     heartbeatTestFixture("Video Playback Resumed");
+    assertTrue(!integration.playbackDelegate.isPaused);
     verify(heartbeat).trackPlay();
   }
 

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -411,6 +411,48 @@ public class AdobeTest {
   }
 
   @Test
+  public void videoPlaybackDelegatePlay() {
+    newVideoSession();
+    try {
+      Thread.sleep(2000);
+    }
+    catch(InterruptedException e) {
+    }
+    assertTrue(integration.playbackDelegate.getCurrentPlaybackTime().equals(2.0));
+  }
+
+  @Test
+  public void videoPlaybackDelegatePaused() {
+    newVideoSession();
+    integration.playbackDelegate.pausePlayhead();
+    Double firstPlayheadPosition = integration.playbackDelegate.getCurrentPlaybackTime();
+    try {
+      Thread.sleep(2000);
+    }
+    catch(InterruptedException e) {
+    }
+    assertTrue(integration.playbackDelegate.getCurrentPlaybackTime().equals(firstPlayheadPosition));
+  }
+
+  @Test
+  public void videoPlaybackDelegatePlayAndPause() {
+    newVideoSession();
+    integration.playbackDelegate.pausePlayhead();
+    try {
+      Thread.sleep(1000);
+    }
+    catch(InterruptedException e) {
+    }
+    integration.playbackDelegate.unPausePlayhead();
+    try {
+      Thread.sleep(3000);
+    }
+    catch(InterruptedException e) {
+    }
+    assertTrue(integration.playbackDelegate.getCurrentPlaybackTime().equals(3.0));
+  }
+
+  @Test
   public void trackVideoPlaybackStarted() {
     ValueMap options = new ValueMap();
     ValueMap integrationSpecificOptions = new ValueMap();

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -537,6 +537,7 @@ public class AdobeTest {
   public void trackVideoBufferStarted() {
     newVideoSession();
     heartbeatTestFixture("Video Playback Buffer Started");
+    assertTrue(integration.playbackDelegate.isPaused);
     verify(heartbeat).trackEvent(MediaHeartbeat.Event.BufferStart, null, null);
   }
 
@@ -544,6 +545,7 @@ public class AdobeTest {
   public void trackVideoBufferComplete() {
     newVideoSession();
     heartbeatTestFixture("Video Playback Buffer Completed");
+    assertTrue(!integration.playbackDelegate.isPaused);
     verify(heartbeat).trackEvent(MediaHeartbeat.Event.BufferComplete, null, null);
   }
 
@@ -551,6 +553,7 @@ public class AdobeTest {
   public void trackVideoSeekStarted() {
     newVideoSession();
     heartbeatTestFixture("Video Playback Seek Started");
+    assertTrue(integration.playbackDelegate.isPaused);
     verify(heartbeat).trackEvent(MediaHeartbeat.Event.SeekStart, null, null);
   }
 


### PR DESCRIPTION
This PR implements a MediaHeartbeatDelegate that allows us to set, pause and resume the position of the video playhead. Relevant tests included.

TO DO in separate PRs:
 
- Guard against overlapping video sessions - i.e. add logic to automatically close existing session and start a new one if a customer sends a "Video Playback Started" event before ending their previous session with a "Video Playback Completed" event.
- Implement `playheadUpdate()` method within delegate - this is necessary to update the position of the playhead after "Video Seek Completed" events.
- Set and update playhead position for live streaming content.
- Explore updating playhead timer when a customer passes a "position" property in a Segment-specced video event.