### PR TITLE
Adds method to update playhead position

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -620,7 +620,7 @@ public class AdobeIntegration extends Integration<Void> {
 
       case "Video Playback Seek Completed":
         Properties seekProperties = track.properties();
-        playbackDelegate.updatePlayheadPosition(seekProperties.getLong("position", 0));
+        playbackDelegate.updatePlayheadPosition(seekProperties.getLong("seekPosition", 0));
         playbackDelegate.resumePlayheadAfterSeeking();
         heartbeat.trackEvent(MediaHeartbeat.Event.SeekComplete, null, null);
         break;

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -194,10 +194,16 @@ public class AdobeIntegration extends Integration<Void> {
      * `getCurrentPlayback()` time invokes this method once per second to resolve the current
      * location of the video playhead:
      *
-     * <p>(currentSystemTime - videoSessionStartTime) - offset
+     * <p>updatedPlayheadPosition + (currentSystemTime - videoSessionStartTime) - offset
+     *
+     * <p>updatedPlayheadPosition represents a user-specified position of the playhead. This is
+     * useful for updating the playhead position after a "Video Playback Seek Completed" event. The
+     * user must provide the updated playhead position in order for this method to update the
+     * playhead position here properly.
      */
     private void incrementPlayheadPosition() {
-      this.playheadPosition = ((System.currentTimeMillis() - initialTime) / 1000) - offset;
+      this.playheadPosition =
+          updatedPlayheadPosition + ((System.currentTimeMillis() - initialTime) / 1000) - offset;
     }
 
     /**
@@ -233,8 +239,8 @@ public class AdobeIntegration extends Integration<Void> {
     }
 
     /**
-     * Resumes invocation of `getCurrentPlaybackTime()` by setting `isPaused` to false. This is
-     * only called when a customer sends a "Video Playback Seek Completed" event.
+     * Resumes invocation of `getCurrentPlaybackTime()` by setting `isPaused` to false. This is only
+     * called when a customer sends a "Video Playback Seek Completed" event.
      */
     public void resumePlayheadAfterSeeking() {
       this.isPaused = false;
@@ -249,7 +255,7 @@ public class AdobeIntegration extends Integration<Void> {
      *     Seek Completed" event. This value is required for accurate reporting in the Adobe
      *     dashboard. It defaults to 0.
      */
-    public void updatePlayhead(Long playheadPosition) {
+    public void updatePlayheadPosition(Long playheadPosition) {
       this.initialTime = System.currentTimeMillis();
       this.updatedPlayheadPosition = playheadPosition;
     }
@@ -614,7 +620,7 @@ public class AdobeIntegration extends Integration<Void> {
 
       case "Video Playback Seek Completed":
         Properties seekProperties = track.properties();
-        playbackDelegate.updatePlayhead(seekProperties.getLong("position", 0));
+        playbackDelegate.updatePlayheadPosition(seekProperties.getLong("position", 0));
         playbackDelegate.resumePlayheadAfterSeeking();
         heartbeat.trackEvent(MediaHeartbeat.Event.SeekComplete, null, null);
         break;

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -147,7 +147,9 @@ public class AdobeIntegration extends Integration<Void> {
    */
   static class PlaybackDelegate implements MediaHeartbeatDelegate {
     /**
-     * The system time in millis at which the current instance of PlaybackDelegate was instantiated
+     * The system time in millis at which the playhead is first set or updated. The playhead is
+     * first set upon instantiation of the PlaybackDelegate. The value is updated whenever
+     * `updatePlayheadPosition()` is invoked.
      */
     long initialTime;
     /** The current playhead position in seconds */

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -3,6 +3,7 @@ package com.segment.analytics.android.integrations.adobeanalytics;
 import android.app.Activity;
 import android.app.Application;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import com.adobe.mobile.Analytics;
 import com.adobe.mobile.Config;
 import com.adobe.primetime.va.simple.MediaHeartbeat;
@@ -578,15 +579,19 @@ public class AdobeTest {
   @Test
   public void trackVideoSeekStarted() {
     newVideoSession();
-    heartbeatTestFixture("Video Playback Seek Started");
+    heartbeatSeekFixture("Video Playback Seek Started", null);
     assertTrue(integration.playbackDelegate.isPaused);
+    assertTrue(integration.playbackDelegate.getCurrentPlaybackTime() == 0.0);
     verify(heartbeat).trackEvent(MediaHeartbeat.Event.SeekStart, null, null);
   }
 
   @Test
   public void trackVideoSeekComplete() {
     newVideoSession();
-    heartbeatTestFixture("Video Playback Seek Completed");
+    Double first = integration.playbackDelegate.getCurrentPlaybackTime();
+    heartbeatSeekFixture("Video Playback Seek Completed", 50L);
+    assertTrue(!integration.playbackDelegate.isPaused);
+    assertTrue(integration.playbackDelegate.getCurrentPlaybackTime() == first + 50.0);
     verify(heartbeat).trackEvent(MediaHeartbeat.Event.SeekComplete, null, null);
   }
 
@@ -755,6 +760,17 @@ public class AdobeTest {
     integration.track(new TrackPayload.Builder()
         .userId("123")
         .event(eventName)
+        .build()
+    );
+  }
+
+  private void heartbeatSeekFixture(String eventName, @Nullable Long position) {
+    integration.track(new TrackPayload.Builder()
+        .userId("123")
+        .event(eventName)
+        .properties(new Properties()
+            .putValue("position", (position != null ? position : 0))
+        )
         .build()
     );
   }

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -764,12 +764,12 @@ public class AdobeTest {
     );
   }
 
-  private void heartbeatSeekFixture(String eventName, @Nullable Long position) {
+  private void heartbeatSeekFixture(String eventName, @Nullable Long seekPosition) {
     integration.track(new TrackPayload.Builder()
         .userId("123")
         .event(eventName)
         .properties(new Properties()
-            .putValue("position", (position != null ? position : 0))
+            .putValue("seekPosition", (seekPosition != null ? seekPosition : 0))
         )
         .build()
     );


### PR DESCRIPTION
- Adds method to update the playhead position when a customer fires a "Video Playback Seek Completed" event
- Customer must pass the new playhead position as a property; otherwise, we'd have no way of knowing the point at which the end user stopped seeking