### PR TITLE
Add/initial playhead offset

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -148,8 +148,8 @@ public class AdobeIntegration extends Integration<Void> {
   static class PlaybackDelegate implements MediaHeartbeatDelegate {
     /**
      * The system time in millis at which the playhead is first set or updated. The playhead is
-     * first set upon instantiation of the PlaybackDelegate. The value is updated whenever
-     * {@link #updatePlayheadPosition(Long)} is invoked.
+     * first set upon instantiation of the PlaybackDelegate. The value is updated whenever {@link
+     * #updatePlayheadPosition(Long)} is invoked.
      */
     long initialTime;
     /** The current playhead position in seconds */
@@ -181,8 +181,8 @@ public class AdobeIntegration extends Integration<Void> {
 
     /**
      * Adobe invokes this method once per second to resolve the current position of the video
-     * playhead. Unless paused, this method increments the value of {@link #playheadPosition} by one every
-     * second by calling {@link #incrementPlayheadPosition()}
+     * playhead. Unless paused, this method increments the value of {@link #playheadPosition} by one
+     * every second by calling {@link #incrementPlayheadPosition()}
      */
     @Override
     public Double getCurrentPlaybackTime() {
@@ -199,10 +199,10 @@ public class AdobeIntegration extends Integration<Void> {
      *
      * <p>updatedPlayheadPosition + (currentSystemTime - videoSessionStartTime) - offset
      *
-     * <p>{@link #updatedPlayheadPosition} represents a user-specified position of the playhead. This is
-     * useful for updating the playhead position after a "Video Content Started" or  "Video Playback Seek Completed" event. The
-     * user must provide the updated playhead position in order for this method to update the
-     * playhead position here properly.
+     * <p>{@link #updatedPlayheadPosition} represents a user-specified position of the playhead.
+     * This is useful for updating the playhead position after a "Video Content Started" or "Video
+     * Playback Seek Completed" event. The user must provide the updated playhead position in order
+     * for this method to update the playhead position here properly.
      */
     private void incrementPlayheadPosition() {
       this.playheadPosition =
@@ -210,9 +210,9 @@ public class AdobeIntegration extends Integration<Void> {
     }
 
     /**
-     * Stores the current playhead position in {@link #pausedPlayheadPosition}. Also stores the system time
-     * at which the video was paused in {@link #pauseStartedTime}. Sets {@link #isPaused} to true so
-     * {@link #getCurrentPlaybackTime()} knows the video is in a paused state.
+     * Stores the current playhead position in {@link #pausedPlayheadPosition}. Also stores the
+     * system time at which the video was paused in {@link #pauseStartedTime}. Sets {@link
+     * #isPaused} to true so {@link #getCurrentPlaybackTime()} knows the video is in a paused state.
      */
     public void pausePlayhead() {
       this.pausedPlayheadPosition = playheadPosition;
@@ -221,9 +221,9 @@ public class AdobeIntegration extends Integration<Void> {
     }
 
     /**
-     * This method sets the {@link #isPaused} flag to false, as well as calculates the {@link #offset} value.
-     * {@link #offset} represents the total cumulative time in seconds a video was in a paused state during
-     * a session. If no offset exists:
+     * This method sets the {@link #isPaused} flag to false, as well as calculates the {@link
+     * #offset} value. {@link #offset} represents the total cumulative time in seconds a video was
+     * in a paused state during a session. If no offset exists:
      *
      * <p>offset = currentSystemTime - timePlayerWasPaused
      *
@@ -242,18 +242,18 @@ public class AdobeIntegration extends Integration<Void> {
     }
 
     /**
-     * Resumes invocation of {@link #getCurrentPlaybackTime()} by setting {@link #isPaused} to false. This is only
-     * called when a customer sends a "Video Playback Seek Completed" event.
+     * Resumes invocation of {@link #getCurrentPlaybackTime()} by setting {@link #isPaused} to
+     * false. This is only called when a customer sends a "Video Playback Seek Completed" event.
      */
     public void resumePlayheadAfterSeeking() {
       this.isPaused = false;
     }
 
     /**
-     * Updates member variables {@link #initialTime} and {@link #updatedPlayheadPosition} whenever either a "Video
-     * Playback Seek Completed" or "Video Content Started" event is received AND contains
-     * properties.seekPosition or properties.position, respectively. After invocation, {@link #initialTime}
-     * is assigned to the system time at which the video event was received.
+     * Updates member variables {@link #initialTime} and {@link #updatedPlayheadPosition} whenever
+     * either a "Video Playback Seek Completed" or "Video Content Started" event is received AND
+     * contains properties.seekPosition or properties.position, respectively. After invocation,
+     * {@link #initialTime} is assigned to the system time at which the video event was received.
      *
      * @param playheadPosition properties.position passed by the customer into a "Video Playback
      *     Seek Completed" or "Video Content Started" event. This value is required for accurate

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -143,20 +143,20 @@ public class AdobeIntegration extends Integration<Void> {
 
   /*
    * PlaybackDelegate implements Adobe's MediaHeartbeatDelegate interface. This implementation allows us
-   * to write logic and returns the position of a video playhead during a video session.
+   * to return the position of a video playhead during a video session.
    */
   static class PlaybackDelegate implements MediaHeartbeatDelegate {
     /**
      * The system time in millis at which the playhead is first set or updated. The playhead is
      * first set upon instantiation of the PlaybackDelegate. The value is updated whenever
-     * `updatePlayheadPosition()` is invoked.
+     * {@link #updatePlayheadPosition(Long)} is invoked.
      */
     long initialTime;
     /** The current playhead position in seconds */
     long playheadPosition;
     /** The position of the playhead in seconds when the video was paused */
     long pausedPlayheadPosition;
-    /** The system time in millis at which `pausePlayhead()` was invoked */
+    /** The system time in millis at which {@link #pausePlayhead} was invoked */
     long pauseStartedTime;
     /**
      * The updated playhead position - this variable is assigned to the value a customer passes as
@@ -181,8 +181,8 @@ public class AdobeIntegration extends Integration<Void> {
 
     /**
      * Adobe invokes this method once per second to resolve the current position of the video
-     * playhead. Unless paused, this method increments the value of `playheadPosition` by one every
-     * second by calling `incrementPlayheadPosition()`
+     * playhead. Unless paused, this method increments the value of {@link #playheadPosition} by one every
+     * second by calling {@link #incrementPlayheadPosition()}
      */
     @Override
     public Double getCurrentPlaybackTime() {
@@ -194,13 +194,13 @@ public class AdobeIntegration extends Integration<Void> {
     }
 
     /**
-     * `getCurrentPlayback()` time invokes this method once per second to resolve the current
+     * {@link #getCurrentPlaybackTime()} invokes this method once per second to resolve the current
      * location of the video playhead:
      *
      * <p>updatedPlayheadPosition + (currentSystemTime - videoSessionStartTime) - offset
      *
-     * <p>updatedPlayheadPosition represents a user-specified position of the playhead. This is
-     * useful for updating the playhead position after a "Video Playback Seek Completed" event. The
+     * <p>{@link #updatedPlayheadPosition} represents a user-specified position of the playhead. This is
+     * useful for updating the playhead position after a "Video Content Started" or  "Video Playback Seek Completed" event. The
      * user must provide the updated playhead position in order for this method to update the
      * playhead position here properly.
      */
@@ -210,9 +210,9 @@ public class AdobeIntegration extends Integration<Void> {
     }
 
     /**
-     * Stores the current playhead position in `pausedPlayheadPosition`. Also stores the system time
-     * at which the video was paused in `pauseStartedTime`. Sets `isPaused` to true so
-     * `getCurrentPlaybackTime()` knows the video is in a paused state.
+     * Stores the current playhead position in {@link #pausedPlayheadPosition}. Also stores the system time
+     * at which the video was paused in {@link #pauseStartedTime}. Sets {@link #isPaused} to true so
+     * {@link #getCurrentPlaybackTime()} knows the video is in a paused state.
      */
     public void pausePlayhead() {
       this.pausedPlayheadPosition = playheadPosition;
@@ -221,8 +221,8 @@ public class AdobeIntegration extends Integration<Void> {
     }
 
     /**
-     * This method sets the `isPaused` flag to false, as well as calculates the `offset` value.
-     * `Offset` represents the total cumulative time in seconds a video was in a paused state during
+     * This method sets the {@link #isPaused} flag to false, as well as calculates the {@link #offset} value.
+     * {@link #offset} represents the total cumulative time in seconds a video was in a paused state during
      * a session. If no offset exists:
      *
      * <p>offset = currentSystemTime - timePlayerWasPaused
@@ -242,7 +242,7 @@ public class AdobeIntegration extends Integration<Void> {
     }
 
     /**
-     * Resumes invocation of `getCurrentPlaybackTime()` by setting `isPaused` to false. This is only
+     * Resumes invocation of {@link #getCurrentPlaybackTime()} by setting {@link #isPaused} to false. This is only
      * called when a customer sends a "Video Playback Seek Completed" event.
      */
     public void resumePlayheadAfterSeeking() {
@@ -250,9 +250,9 @@ public class AdobeIntegration extends Integration<Void> {
     }
 
     /**
-     * Updates member variables `initialTime` and `updatedPlayheadPosition` whenever either a "Video
+     * Updates member variables {@link #initialTime} and {@link #updatedPlayheadPosition} whenever either a "Video
      * Playback Seek Completed" or "Video Content Started" event is received AND contains
-     * properties.seekPosition or properties.position, respectively. After invocation, `initialTime`
+     * properties.seekPosition or properties.position, respectively. After invocation, {@link #initialTime}
      * is assigned to the system time at which the video event was received.
      *
      * @param playheadPosition properties.position passed by the customer into a "Video Playback

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -152,20 +152,16 @@ public class AdobeIntegration extends Integration<Void> {
      * `updatePlayheadPosition()` is invoked.
      */
     long initialTime;
-    /**
-     * The initial position of the playhead if not 0. The user must pass this value into a video
-     * event as the value of properties.position.
-     */
-    long initialPlayheadPosition;
     /** The current playhead position in seconds */
     long playheadPosition;
     /** The position of the playhead in seconds when the video was paused */
     long pausedPlayheadPosition;
-    /** The system time in millis at which pausePlayhead() was invoked */
+    /** The system time in millis at which `pausePlayhead()` was invoked */
     long pauseStartedTime;
     /**
      * The updated playhead position - this variable is assigned to the value a customer passes as
-     * "position" in a "Video Playback Seek Completed" event, defaulting to 0
+     * properties.seekPosition in a "Video Playback Seek Completed" event or properties.position in
+     * a "Video Content Started" event
      */
     long updatedPlayheadPosition;
     /** The total time in seconds a video has been in a paused state during a video session */
@@ -210,10 +206,7 @@ public class AdobeIntegration extends Integration<Void> {
      */
     private void incrementPlayheadPosition() {
       this.playheadPosition =
-          initialPlayheadPosition
-              + updatedPlayheadPosition
-              + ((System.currentTimeMillis() - initialTime) / 1000)
-              - offset;
+          updatedPlayheadPosition + ((System.currentTimeMillis() - initialTime) / 1000) - offset;
     }
 
     /**
@@ -258,14 +251,13 @@ public class AdobeIntegration extends Integration<Void> {
 
     /**
      * Updates member variables `initialTime` and `updatedPlayheadPosition` whenever either a "Video
-     * Playback Seek Completed" or "Video Playback Content Started" event is received AND contains
-     * properties.position or properties.seekPosition - these properties should only serve to update
-     * the playhead position. After invocation, `initialTime` is assigned to the system time at
-     * which the video event was received.
+     * Playback Seek Completed" or "Video Content Started" event is received AND contains
+     * properties.seekPosition or properties.position, respectively. After invocation, `initialTime`
+     * is assigned to the system time at which the video event was received.
      *
      * @param playheadPosition properties.position passed by the customer into a "Video Playback
-     *     Seek Completed" or "Video Playback Content Started" event. This value is required for
-     *     accurate reporting in the Adobe dashboard. It defaults to 0.
+     *     Seek Completed" or "Video Content Started" event. This value is required for accurate
+     *     reporting in the Adobe dashboard. It defaults to 0.
      */
     public void updatePlayheadPosition(Long playheadPosition) {
       this.initialTime = System.currentTimeMillis();

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -513,6 +513,7 @@ public class AdobeTest {
   @Test
   public void trackVideoContentStarted() {
     newVideoSession();
+
     integration.track(new TrackPayload.Builder()
         .userId("123")
         .event("Video Content Started")
@@ -521,7 +522,8 @@ public class AdobeTest {
             .putValue("contentAssetId", "123")
             .putValue("totalLength", 100D)
             .putValue("startTime", 10D)
-            .putValue("indexPosition", 1L))
+            .putValue("indexPosition", 1L)
+            .putValue("position", 35))
         .build()
     );
 
@@ -531,6 +533,7 @@ public class AdobeTest {
     videoMetadata.put("totalLength", "100.0");
     videoMetadata.put("startTime", "10.0");
     videoMetadata.put("indexPosition", "1");
+    videoMetadata.put("position", "35");
 
     MediaObject mediaChapter = MediaHeartbeat.createChapterObject(
         "You Win or You Die",
@@ -541,6 +544,7 @@ public class AdobeTest {
 
     mediaChapter.setValue(MediaHeartbeat.MediaObjectKey.StandardVideoMetadata, new HashMap<String, String>());
 
+    assertTrue(integration.playbackDelegate.getCurrentPlaybackTime() == 35.0);
     verify(heartbeat).trackPlay();
     verify(heartbeat).trackEvent(eq(MediaHeartbeat.Event.ChapterStart), isEqualToComparingFieldByFieldRecursively(mediaChapter),
         eq(videoMetadata));


### PR DESCRIPTION
- properties.seekPosition  will set an initial playhead offset if sent with a "Video Playback Seek Started" and properties.position will set an initial playhead offset if sent with a "Video Playback Content Started" event
- This is useful if a video begins playback from an index of other than 0 - many modern video players allow users to link to specific points in the video that aren't the very beginning