### PR TITLE
Support Video Quality Updated events

### DIFF
--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -679,6 +679,26 @@ public class AdobeTest {
   }
 
   @Test
+  public void trackVideoQualityUpdated() {
+    integration.playbackDelegate = new AdobeIntegration.PlaybackDelegate();
+    integration.track(new TrackPayload.Builder()
+        .userId("123")
+        .event("Video Quality Updated")
+        .properties(new Properties()
+            .putValue("bitrate", 12000)
+            .putValue("startupTime", 1)
+            .putValue("fps", 50)
+            .putValue("droppedFrames", 1))
+        .build()
+    );
+
+    assertTrue(integration.playbackDelegate.bitrate == 12000);
+    assertTrue(integration.playbackDelegate.startupTime == 1);
+    assertTrue(integration.playbackDelegate.fps == 50);
+    assertTrue(integration.playbackDelegate.droppedFrames == 1);
+  }
+
+  @Test
   public void identify() {
     integration.identify(new IdentifyPayload.Builder()
         .userId("123")

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -692,10 +692,14 @@ public class AdobeTest {
         .build()
     );
 
-    assertTrue(integration.playbackDelegate.bitrate == 12000);
-    assertTrue(integration.playbackDelegate.startupTime == 1);
-    assertTrue(integration.playbackDelegate.fps == 50);
-    assertTrue(integration.playbackDelegate.droppedFrames == 1);
+    MediaObject expectedMediaObject = MediaHeartbeat.createQoSObject(
+        12000L,
+        1D,
+        50D,
+        1L
+    );
+
+    assertThat(integration.playbackDelegate.qosData).isEqualToComparingFieldByField(expectedMediaObject);
   }
 
   @Test


### PR DESCRIPTION
@f2prateek This is what I was thinking re: supporting quality of service tracking. The delegate's quality member variables will only be updated whenever a customer sends a "Video Quality Updated" event. Adobe invokes `getQosObject()` every ten seconds regardless of whether a user has provided updated quality of service data. Thanks!

@ladanazita "Video Quality Updated" can be changed if you have other thoughts. Regardless, even though this event isn't specced, I think it makes the most sense as it's the simplest approach for a customer to provide updated quality of service data to the delegate.