### PR TITLE
Break standard ad metadata into its own map

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -706,7 +706,6 @@ public class AdobeIntegration extends Integration<Void> {
                 videoAdProperties.getLong("indexPosition", 0),
                 videoAdProperties.getDouble("totalLength", 0));
 
-        standardAdMetadata.remove(MediaHeartbeat.VideoMetadataKeys.ASSET_ID);
         mediaAdInfo.setValue(MediaHeartbeat.MediaObjectKey.StandardAdMetadata, standardAdMetadata);
 
         heartbeat.trackEvent(MediaHeartbeat.Event.AdStart, mediaAdInfo, adMetadata);

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -652,6 +652,7 @@ public class AdobeTest {
 
     HashMap<String, String> adMetadata = new HashMap<>();
     adMetadata.put("title", "Car Commercial");
+    adMetadata.put("assetId", "123");
     adMetadata.put("totalLength", "10.0");
     adMetadata.put("indexPosition", "1");
 


### PR DESCRIPTION
- Breaks out standard ad metadata properties into its own map; this will be useful moving forward to prevent overlap with properties (i.e. depending on the event type, Segment maps "publisher" as either "advertiser" or "originator" to Adobe
- This may will likely also grow if we map to more of Adobe's specced ad properties in the future - they have five that we currently don't support