### PR TITLE
Require non-standard video and ad metadata to be mapped as contextValues

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -391,7 +391,7 @@ public class AdobeIntegration extends Integration<Void> {
     logger.verbose("Analytics.trackAction(%s, %s);", eventName, mappedProperties);
   }
 
-  private Map<String, Object> mapProperties(Properties properties) {
+  private Properties mapProperties(Properties properties) {
     Properties propertiesCopy = new Properties();
     propertiesCopy.putAll(properties);
 
@@ -401,7 +401,7 @@ public class AdobeIntegration extends Integration<Void> {
       propertiesCopy.remove("products");
     }
 
-    Map<String, Object> mappedProperties = new HashMap<>();
+    Properties mappedProperties = new Properties();
 
     if (!isNullOrEmpty(contextValues)) {
       for (Map.Entry<String, Object> entry : properties.entrySet()) {
@@ -571,8 +571,7 @@ public class AdobeIntegration extends Integration<Void> {
 
         Map<String, String> standardVideoMetadata = new HashMap<>();
         Properties videoProperties = mapStandardVideoMetadata(properties, standardVideoMetadata);
-        HashMap<String, String> videoMetadata = new HashMap<>();
-        videoMetadata.putAll(videoProperties.toStringMap());
+        Properties videoMetadata = mapProperties(videoProperties);
 
         MediaObject mediaInfo =
             MediaHeartbeat.createMediaObject(
@@ -586,7 +585,7 @@ public class AdobeIntegration extends Integration<Void> {
         mediaInfo.setValue(
             MediaHeartbeat.MediaObjectKey.StandardVideoMetadata, standardVideoMetadata);
 
-        heartbeat.trackSessionStart(mediaInfo, videoMetadata);
+        heartbeat.trackSessionStart(mediaInfo, videoMetadata.toStringMap());
         break;
 
       case "Video Playback Paused":
@@ -604,8 +603,7 @@ public class AdobeIntegration extends Integration<Void> {
         Map<String, String> standardChapterMetadata = new HashMap<>();
         Properties chapterProperties =
             mapStandardVideoMetadata(videoContentProperties, standardChapterMetadata);
-        HashMap<String, String> chapterMetadata = new HashMap<>();
-        chapterMetadata.putAll(chapterProperties.toStringMap());
+        Properties chapterMetadata = mapProperties(chapterProperties);
 
         MediaObject mediaChapter =
             MediaHeartbeat.createChapterObject(
@@ -621,7 +619,8 @@ public class AdobeIntegration extends Integration<Void> {
           playbackDelegate.updatePlayheadPosition(videoContentProperties.getLong("position", 0));
         }
         heartbeat.trackPlay();
-        heartbeat.trackEvent(MediaHeartbeat.Event.ChapterStart, mediaChapter, chapterMetadata);
+        heartbeat.trackEvent(
+            MediaHeartbeat.Event.ChapterStart, mediaChapter, chapterMetadata.toStringMap());
         break;
 
       case "Video Content Completed":
@@ -673,8 +672,7 @@ public class AdobeIntegration extends Integration<Void> {
         Properties videoAdProperties = track.properties();
         Map<String, String> standardAdMetadata = new HashMap<>();
         Properties adProperties = mapStandardVideoMetadata(videoAdProperties, standardAdMetadata);
-        HashMap<String, String> adMetadata = new HashMap<>();
-        adMetadata.putAll(adProperties.toStringMap());
+        Properties adMetadata = mapProperties(adProperties);
 
         MediaObject mediaAdInfo =
             MediaHeartbeat.createAdObject(
@@ -689,7 +687,7 @@ public class AdobeIntegration extends Integration<Void> {
         standardAdMetadata.remove(MediaHeartbeat.VideoMetadataKeys.ASSET_ID);
         mediaAdInfo.setValue(MediaHeartbeat.MediaObjectKey.StandardAdMetadata, standardAdMetadata);
 
-        heartbeat.trackEvent(MediaHeartbeat.Event.AdStart, mediaAdInfo, adMetadata);
+        heartbeat.trackEvent(MediaHeartbeat.Event.AdStart, mediaAdInfo, adMetadata.toStringMap());
         break;
 
       case "Video Ad Skipped":

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -584,8 +584,7 @@ public class AdobeIntegration extends Integration<Void> {
                 standardVideoMetadata,
                 // eventType
                 "coreVideo");
-        Map<String, String> videoMetadata = new HashMap<>();
-        videoMetadata.putAll(videoProperties.toStringMap());
+        Properties videoMetadata = mapProperties(videoProperties);
 
         MediaObject mediaInfo =
             MediaHeartbeat.createMediaObject(
@@ -621,8 +620,7 @@ public class AdobeIntegration extends Integration<Void> {
                 standardChapterMetadata,
                 // eventType
                 "coreVideo");
-        Map<String, String> chapterMetadata = new HashMap<>();
-        chapterMetadata.putAll(chapterProperties.toStringMap());
+        Properties chapterMetadata = mapProperties(chapterProperties);
 
         MediaObject mediaChapter =
             MediaHeartbeat.createChapterObject(
@@ -697,8 +695,7 @@ public class AdobeIntegration extends Integration<Void> {
                 standardAdMetadata,
                 // eventType
                 "ad");
-        Map<String, String> adMetadata = new HashMap<>();
-        adMetadata.putAll(adProperties.toStringMap());
+        Properties adMetadata = mapProperties(adProperties);
 
         MediaObject mediaAdInfo =
             MediaHeartbeat.createAdObject(

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -665,9 +665,6 @@ public class AdobeTest {
 
     Map<String, String> adMetadata = new HashMap<>();
     adMetadata.put("adobe.title", "Car Commercial");
-    adMetadata.put("assetId", "123");
-    adMetadata.put("totalLength", "10.0");
-    adMetadata.put("indexPosition", "1");
 
     Map<String, String> standardAdMetadata = new HashMap<>();
     standardAdMetadata.put(MediaHeartbeat.AdMetadataKeys.ADVERTISER, "Lexus");

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -438,6 +438,9 @@ public class AdobeTest {
 
   @Test
   public void trackVideoPlaybackStarted() {
+    integration.contextValues = new HashMap<>();
+    integration.contextValues.put("random metadata", "adobe.random");
+
     ValueMap options = new ValueMap();
     ValueMap integrationSpecificOptions = new ValueMap();
     integrationSpecificOptions.put("ovpName", "HTML 5");
@@ -474,10 +477,7 @@ public class AdobeTest {
     standardVideoMetadata.put(MediaHeartbeat.VideoMetadataKeys.STREAM_FORMAT, MediaHeartbeat.StreamType.VOD);
 
     HashMap<String, String> videoMetadata = new HashMap<>();
-    videoMetadata.put("title", "You Win or You Die");
-    videoMetadata.put("contentAssetId", "123");
-    videoMetadata.put("totalLength", "100.0");
-    videoMetadata.put("random metadata", "something super random");
+    videoMetadata.put("adobe.random", "something super random");
 
     // create a media object; values can be null
     MediaObject mediaInfo = MediaHeartbeat.createMediaObject(
@@ -512,6 +512,9 @@ public class AdobeTest {
 
   @Test
   public void trackVideoContentStarted() {
+    integration.contextValues = new HashMap<>();
+    integration.contextValues.put("title", "adobe.title");
+
     newVideoSession();
 
     integration.track(new TrackPayload.Builder()
@@ -528,12 +531,7 @@ public class AdobeTest {
     );
 
     HashMap<String, String> videoMetadata = new HashMap<>();
-    videoMetadata.put("title", "You Win or You Die");
-    videoMetadata.put("contentAssetId", "123");
-    videoMetadata.put("totalLength", "100.0");
-    videoMetadata.put("startTime", "10.0");
-    videoMetadata.put("indexPosition", "1");
-    videoMetadata.put("position", "35");
+    videoMetadata.put("adobe.title", "You Win or You Die");
 
     MediaObject mediaChapter = MediaHeartbeat.createChapterObject(
         "You Win or You Die",
@@ -630,6 +628,9 @@ public class AdobeTest {
 
   @Test
   public void trackVideoAdStarted() {
+    integration.contextValues = new HashMap<>();
+    integration.contextValues.put("title", "adobe.title");
+
     newVideoSession();
     integration.track(new TrackPayload.Builder()
         .userId("123")
@@ -651,9 +652,7 @@ public class AdobeTest {
     );
 
     HashMap<String, String> adMetadata = new HashMap<>();
-    adMetadata.put("title", "Car Commercial");
-    adMetadata.put("totalLength", "10.0");
-    adMetadata.put("indexPosition", "1");
+    adMetadata.put("adobe.title", "Car Commercial");
 
     Map<String, String> standardAdMetadata = new HashMap<>();
     standardAdMetadata.put(MediaHeartbeat.AdMetadataKeys.ADVERTISER, "Lexus");


### PR DESCRIPTION
This code update runs all non-standard video and ad metadata through our `mapProperties` helper function - this means that customers are required to map Segment property keys to Adobe contextVariables if they want Segment to pass them along to Adobe.