### PR TITLE
Formatting Fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,22 +1,16 @@
 GROUP=com.segment.analytics.android.integrations
-
 VERSION_CODE=001
 VERSION_NAME=0.0.1
-
 POM_ARTIFACT_ID=adobe-analytics
 POM_PACKAGING=jar
-
 POM_NAME=Adobe Analytics Integration
 POM_DESCRIPTION=Adobe Analytics Integration for Segment Android Analytics
-
 POM_URL=http://github.com/segment-integrations/analytics-android-integration-adobe-analytics
 POM_SCM_URL=http://github.com/segment-integrations/analytics-android-integration-adobe-analytics
 POM_SCM_CONNECTION=scm:git:git://github.com/segment-integrations/analytics-android-integration-adobe-analytics.git
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/segment-integrations/analytics-android-integration-adobe-analytics.git
-
 POM_LICENCE_NAME=The MIT License (MIT)
 POM_LICENCE_URL=http://opensource.org/licenses/MIT
 POM_LICENCE_DIST=repo
-
 POM_DEVELOPER_ID=segmentio
 POM_DEVELOPER_NAME=Segment, Inc.

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -148,17 +148,18 @@ public class AdobeIntegration extends Integration<Void> {
    * to return the position of a video playhead during a video session.
    */
   static class PlaybackDelegate implements MediaHeartbeatDelegate {
+
     /**
      * The system time in millis at which the playhead is first set or updated. The playhead is
      * first set upon instantiation of the PlaybackDelegate. The value is updated whenever {@link
      * #updatePlayheadPosition(Long)} is invoked.
      */
     long initialTime;
-    /** The current playhead position in seconds */
+    /** The current playhead position in seconds. */
     long playheadPosition;
-    /** The position of the playhead in seconds when the video was paused */
+    /** The position of the playhead in seconds when the video was paused. */
     long pausedPlayheadPosition;
-    /** The system time in millis at which {@link #pausePlayhead} was invoked */
+    /** The system time in millis at which {@link #pausePlayhead} was invoked. */
     long pauseStartedTime;
     /**
      * The updated playhead position - this variable is assigned to the value a customer passes as
@@ -166,7 +167,7 @@ public class AdobeIntegration extends Integration<Void> {
      * a "Video Content Started" event
      */
     long updatedPlayheadPosition;
-    /** The total time in seconds a video has been in a paused state during a video session */
+    /** The total time in seconds a video has been in a paused state during a video session. */
     long offset = 0;
     /** Whether the video playhead is in a paused state. */
     boolean isPaused = false;
@@ -329,7 +330,9 @@ public class AdobeIntegration extends Integration<Void> {
     super.identify(identify);
 
     String userId = identify.userId();
-    if (isNullOrEmpty(userId)) return;
+    if (isNullOrEmpty(userId)) {
+      return;
+    }
     Config.setUserIdentifier(userId);
     logger.verbose("Config.setUserIdentifier(%s);", userId);
   }

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -48,14 +48,14 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(RobolectricTestRunner.class)
 @PrepareForTest({Analytics.class, Config.class, MediaHeartbeat.class})
 @org.robolectric.annotation.Config(constants = BuildConfig.class)
-@PowerMockIgnore({ "org.mockito.*", "org.robolectric.*", "android.*", "org.json.*" })
+@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*", "org.json.*"})
 public class AdobeTest {
 
   @Rule public PowerMockRule rule = new PowerMockRule();
+  @Mock private MediaHeartbeat heartbeat;
+  @Mock private com.segment.analytics.Analytics analytics;
+  @Mock private Application context;
   private AdobeIntegration integration;
-  private @Mock MediaHeartbeat heartbeat;
-  private @Mock com.segment.analytics.Analytics analytics;
-  private @Mock Application context;
   private AdobeIntegration.HeartbeatFactory mockHeartbeatFactory = new AdobeIntegration.HeartbeatFactory() {
     @Override
     public MediaHeartbeat get(MediaHeartbeatDelegate delegate, MediaHeartbeatConfig config) {
@@ -70,7 +70,8 @@ public class AdobeTest {
     PowerMockito.mockStatic(Analytics.class);
     when(analytics.getApplication()).thenReturn(context);
     integration = new AdobeIntegration(new ValueMap()
-        .putValue("heartbeatTrackingServer", "true"), analytics, Logger.with(NONE), mockHeartbeatFactory);
+        .putValue("heartbeatTrackingServer", "true"), analytics, Logger.with(NONE),
+        mockHeartbeatFactory);
   }
 
   @Test
@@ -85,8 +86,8 @@ public class AdobeTest {
         .putValue("contextValues", new HashMap<String, Object>())
         .putValue("productIdentifier", "id")
         .putValue("adobeVerboseLogging", true),
-      analytics,
-      Logger.with(VERBOSE),
+        analytics,
+        Logger.with(VERBOSE),
         mockHeartbeatFactory);
 
     verifyStatic();
@@ -102,16 +103,18 @@ public class AdobeTest {
     // all default arguments have not yet been defined
   }
 
-  @Test public void activityCreate() {
+  @Test
+  public void activityCreate() {
     Activity activity = mock(Activity.class);
-    Bundle savedInstanceState = mock (Bundle.class);
+    Bundle savedInstanceState = mock(Bundle.class);
     integration.onActivityCreated(activity, savedInstanceState);
 
     verifyStatic();
     Config.setContext(activity.getApplicationContext());
   }
 
-  @Test public void activityPause() {
+  @Test
+  public void activityPause() {
     Activity activity = mock(Activity.class);
     integration.onActivityPaused(activity);
 
@@ -119,7 +122,8 @@ public class AdobeTest {
     Config.pauseCollectingLifecycleData();
   }
 
-  @Test public void activityResume() {
+  @Test
+  public void activityResume() {
     Activity activity = mock(Activity.class);
     integration.onActivityResumed(activity);
 
@@ -293,13 +297,13 @@ public class AdobeTest {
         .event("Checkout Started")
         .properties(new Properties()
             .putProducts(new Product("123", "ABC", 10.0)
-                .putName("shoes")
-                .putValue("category", "athletic")
-                .putValue("quantity", 2),
-              new Product("456", "DEF", 20.0)
-                .putName("jeans")
-                .putValue("category", "casual")
-                .putValue("quantity", 1)))
+                    .putName("shoes")
+                    .putValue("category", "athletic")
+                    .putValue("quantity", 2),
+                new Product("456", "DEF", 20.0)
+                    .putName("jeans")
+                    .putValue("category", "casual")
+                    .putValue("quantity", 1)))
         .build()
     );
 
@@ -432,7 +436,8 @@ public class AdobeTest {
     integration.playbackDelegate = new AdobeIntegration.PlaybackDelegate();
     integration.playbackDelegate.pausePlayhead();
     Thread.sleep(1000);
-    integration.playbackDelegate.unPausePlayhead();Thread.sleep(3000);
+    integration.playbackDelegate.unPausePlayhead();
+    Thread.sleep(3000);
     assertTrue(integration.playbackDelegate.getCurrentPlaybackTime().equals(3.0));
   }
 
@@ -463,7 +468,7 @@ public class AdobeTest {
         .build()
     );
 
-    Map <String, String> standardVideoMetadata = new HashMap<>();
+    Map<String, String> standardVideoMetadata = new HashMap<>();
     standardVideoMetadata.put(MediaHeartbeat.VideoMetadataKeys.ASSET_ID, "123");
     standardVideoMetadata.put(MediaHeartbeat.VideoMetadataKeys.SHOW, "Game of Thrones");
     standardVideoMetadata.put(MediaHeartbeat.VideoMetadataKeys.SEASON, "1");
@@ -471,7 +476,8 @@ public class AdobeTest {
     standardVideoMetadata.put(MediaHeartbeat.VideoMetadataKeys.GENRE, "fantasy");
     standardVideoMetadata.put(MediaHeartbeat.VideoMetadataKeys.NETWORK, "HBO");
     standardVideoMetadata.put(MediaHeartbeat.VideoMetadataKeys.FIRST_AIR_DATE, "2011");
-    standardVideoMetadata.put(MediaHeartbeat.VideoMetadataKeys.STREAM_FORMAT, MediaHeartbeat.StreamType.VOD);
+    standardVideoMetadata
+        .put(MediaHeartbeat.VideoMetadataKeys.STREAM_FORMAT, MediaHeartbeat.StreamType.VOD);
 
     HashMap<String, String> videoMetadata = new HashMap<>();
     videoMetadata.put("title", "You Win or You Die");
@@ -542,11 +548,13 @@ public class AdobeTest {
         10D
     );
 
-    mediaChapter.setValue(MediaHeartbeat.MediaObjectKey.StandardVideoMetadata, new HashMap<String, String>());
+    mediaChapter.setValue(MediaHeartbeat.MediaObjectKey.StandardVideoMetadata,
+        new HashMap<String, String>());
 
     assertTrue(integration.playbackDelegate.getCurrentPlaybackTime() == 35.0);
     verify(heartbeat).trackPlay();
-    verify(heartbeat).trackEvent(eq(MediaHeartbeat.Event.ChapterStart), isEqualToComparingFieldByFieldRecursively(mediaChapter),
+    verify(heartbeat).trackEvent(eq(MediaHeartbeat.Event.ChapterStart),
+        isEqualToComparingFieldByFieldRecursively(mediaChapter),
         eq(videoMetadata));
   }
 
@@ -607,7 +615,8 @@ public class AdobeTest {
         .userId("123")
         .event("Video Ad Break Started")
         .properties(new Properties()
-            .putValue("title", "Car Commercial") // should this be pre-roll, mid-roll or post-roll instead?
+            .putValue("title",
+                "Car Commercial") // Should this be pre-roll, mid-roll or post-roll instead?
             .putValue("startTime", 10D)
             .putValue("indexPosition", 1L))
         .build()
@@ -619,7 +628,8 @@ public class AdobeTest {
         10D
     );
 
-    verify(heartbeat).trackEvent(eq(MediaHeartbeat.Event.AdBreakStart), isEqualToComparingFieldByFieldRecursively(mediaAdBreakInfo), eq((Map) null));
+    verify(heartbeat).trackEvent(eq(MediaHeartbeat.Event.AdBreakStart),
+        isEqualToComparingFieldByFieldRecursively(mediaAdBreakInfo), eq((Map) null));
   }
 
   @Test
@@ -660,7 +670,8 @@ public class AdobeTest {
     standardAdMetadata.put(MediaHeartbeat.AdMetadataKeys.ADVERTISER, "Lexus");
     mediaAdInfo.setValue(MediaHeartbeat.MediaObjectKey.StandardAdMetadata, standardAdMetadata);
 
-    verify(heartbeat).trackEvent(eq(MediaHeartbeat.Event.AdStart), isEqualToComparingFieldByFieldRecursively(mediaAdInfo), eq(adMetadata));
+    verify(heartbeat).trackEvent(eq(MediaHeartbeat.Event.AdStart),
+        isEqualToComparingFieldByFieldRecursively(mediaAdInfo), eq(adMetadata));
   }
 
   @Test
@@ -700,7 +711,8 @@ public class AdobeTest {
         1L
     );
 
-    assertThat(integration.playbackDelegate.qosData).isEqualToComparingFieldByField(expectedMediaObject);
+    assertThat(integration.playbackDelegate.qosData)
+        .isEqualToComparingFieldByField(expectedMediaObject);
   }
 
   @Test
@@ -708,7 +720,7 @@ public class AdobeTest {
     integration.identify(new IdentifyPayload.Builder()
         .userId("123")
         .traits(new Traits())
-    .build());
+        .build());
 
     verifyStatic();
     Config.setUserIdentifier("123");
@@ -814,7 +826,7 @@ public class AdobeTest {
   }
 
   private static <T> T isEqualToComparingFieldByFieldRecursively(final T expected) {
-    return argThat(new AssertionMatcher<T>(){
+    return argThat(new AssertionMatcher<T>() {
       @Override
       public void assertion(T actual) throws AssertionError {
         assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);


### PR DESCRIPTION
Changes are described here:

`AdobeIntegration.java`
1. Make comments sentences consistently, before this there was a mix.
2. Use line breaks after statements (for if-else https://google.github.io/styleguide/javaguide.html#s4.3-one-statement-per-line).

`AdobeTest.java`
1. Consistently order qualifiers and annotations on members. See https://google.github.io/styleguide/javaguide.html#s4.8.5-annotations.
2. Consistently use line break after annotations on methods. See https://google.github.io/styleguide/javaguide.html#s4.8.5-annotations.
3. Use line breaks after statements (for if-else https://google.github.io/styleguide/javaguide.html#s4.3-one-statement-per-line).
4. Reformat some lines to fit column width. https://google.github.io/styleguide/javaguide.html#s4.4-column-limit.

`gradle.properties`
1. Group fields for clarity.