### PR TITLE
Export CIRCLE_JDK_VERSION in circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
      - image: circleci/android:api-26-alpha
    environment:
      JVM_OPTS: -Xmx3200m
+     CIRCLE_JDK_VERSION: oraclejdk8
    steps:
      - checkout
      - restore_cache:


### PR DESCRIPTION
- Export CIRCLE_JDK_VERSION in Circle config so we can deploy snapshots