### PR TITLE
Add/map adbreak metadata

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -674,7 +674,9 @@ public class AdobeIntegration extends Integration<Void> {
                 videoAdBreakProperties.getLong("indexPosition", 1), // Segment does not spec this
                 videoAdBreakProperties.getDouble("startTime", 0));
 
-        heartbeat.trackEvent(MediaHeartbeat.Event.AdBreakStart, mediaAdBreakInfo, null);
+        Properties adBreakMetadata = mapProperties(videoAdBreakProperties);
+
+        heartbeat.trackEvent(MediaHeartbeat.Event.AdBreakStart, mediaAdBreakInfo, adBreakMetadata.toStringMap());
         break;
 
       case "Video Ad Break Completed":

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeIntegration.java
@@ -673,10 +673,10 @@ public class AdobeIntegration extends Integration<Void> {
                 videoAdBreakProperties.getString("title"),
                 videoAdBreakProperties.getLong("indexPosition", 1), // Segment does not spec this
                 videoAdBreakProperties.getDouble("startTime", 0));
-
         Properties adBreakMetadata = mapProperties(videoAdBreakProperties);
 
-        heartbeat.trackEvent(MediaHeartbeat.Event.AdBreakStart, mediaAdBreakInfo, adBreakMetadata.toStringMap());
+        heartbeat.trackEvent(
+            MediaHeartbeat.Event.AdBreakStart, mediaAdBreakInfo, adBreakMetadata.toStringMap());
         break;
 
       case "Video Ad Break Completed":

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/AdobeTest.java
@@ -622,7 +622,11 @@ public class AdobeTest {
 
   @Test
   public void trackVideoAdBreakStarted() {
+    integration.contextValues = new HashMap<>();
+    integration.contextValues.put("contextValue", "adobe.context.value");
+
     newVideoSession();
+
     integration.track(new TrackPayload.Builder()
         .userId("123")
         .event("Video Ad Break Started")
@@ -630,7 +634,8 @@ public class AdobeTest {
             .putValue("title",
                 "Car Commercial") // Should this be pre-roll, mid-roll or post-roll instead?
             .putValue("startTime", 10D)
-            .putValue("indexPosition", 1L))
+            .putValue("indexPosition", 1L)
+            .putValue("contextValue", "value"))
         .build()
     );
 
@@ -639,9 +644,12 @@ public class AdobeTest {
         1L,
         10D
     );
+
+    Map<String, String> adBreakMetadata = new HashMap<>();
+    adBreakMetadata.put("adobe.context.value", "value");
     
     verify(heartbeat).trackEvent(eq(MediaHeartbeat.Event.AdBreakStart),
-        isEqualToComparingFieldByFieldRecursively(mediaAdBreakInfo), eq((Map<String, String>) null));
+        isEqualToComparingFieldByFieldRecursively(mediaAdBreakInfo), eq(adBreakMetadata));
   }
 
   @Test


### PR DESCRIPTION
- Maps custom video metadata to Ad Break events.
- Adobe doesn't give any indication that Ad Breaks accept standard ad metadata, so we don't map those for the moment.