### PR TITLE
export CIRCLE_JDK_VERSION in CI build so we can deploy snapshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
      - image: circleci/android:api-26-alpha
    environment:
      JVM_OPTS: -Xmx3200m
+     CIRCLE_JDK_VERSION: oraclejdk8
    steps:
      - checkout
      - restore_cache:


### PR DESCRIPTION
- segment-bot creds now in Circle