### PR TITLE
[DEST-1097] Bump Adobe SDK to v4.17.9.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     resource_class: small
     docker:
-      - image: circleci/android:api-25-alpha
+      - image: circleci/android:api-28
         environment:
           ANDROID_HOME: /home/circleci/android
           CIRCLE_JDK_VERSION: oraclejdk8
@@ -29,8 +29,8 @@ jobs:
             - /home/circleci/.android
             - /home/circleci/android
             - /home/circleci/.gradle
-            - /usr/local/android-sdk-linux/platforms/android-25
-            - /usr/local/android-sdk-linux/build-tools/25.0.0
+            - /usr/local/android-sdk-linux/platforms/android-28
+            - /usr/local/android-sdk-linux/build-tools/28.0.0
             - /usr/local/android-sdk-linux/extras/android/m2repository
       - store_artifacts:
           path: analytics-core/build/test-report
@@ -48,7 +48,7 @@ jobs:
   publish_snapshot:
     resource_class: small
     docker:
-      - image: circleci/android:api-25-alpha
+      - image: circleci/android:api-28
         environment:
           ANDROID_HOME: /home/circleci/android
           CIRCLE_JDK_VERSION: oraclejdk8
@@ -73,7 +73,7 @@ jobs:
   publish:
       resource_class: small
       docker:
-        - image: circleci/android:api-25-alpha
+        - image: circleci/android:api-28
           environment:
             ANDROID_HOME: /home/circleci/android
             CIRCLE_JDK_VERSION: oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 
     api fileTree(dir: 'libs', include: ['*.jar'])
     api 'com.segment.analytics.android:analytics:4.3.1'
-    api 'com.adobe.mobile:adobeMobileLibrary:4.17.0'
+    api 'com.adobe.mobile:adobeMobileLibrary:4.17.9'
 
     testImplementation 'com.segment.analytics.android:analytics-tests:4.3.1'
     testImplementation 'junit:junit:4.12'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=1.2.0
+VERSION=1.2.0-SNAPSHOT
 
 POM_ARTIFACT_ID=adobe-analytics
 POM_PACKAGING=jar


### PR DESCRIPTION
This is the CI build we care about: https://ci.segment.com/gh/segment-integrations/analytics-android-integration-adobe-analytics/36?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
 
**Builds on `circle.com` are failing b/c the "Android" context has for some reason been deleted there.

**What does this PR do?**
- Bump Adobe SDK dependency to v4.17.9.
- Here are my notes on Adobe's changelog: https://paper.dropbox.com/doc/DEST-1096-Update-Adobe-SDKs--AlB129qnRfOnq4LHZGYkJcsVAg-9DUwD8gxgVMm0eBkeSR7n

**Are there breaking changes in this PR?**
- Based on my reading of their changelog and compiling with v4.17.9 there shouldn't be any breaking changes. There are definitely no compile-time errors.

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
- n/a

**Any background context you want to provide?**
- n/a

**Is there parity with the server-side/analytics.js integration (if applicable)?**
- n/a

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**
- n/a

**What are the relevant tickets?**
https://segment.atlassian.net/browse/DEST-1097

**Link to CC ticket**
- n/a

**List all the tests accounts you have used to make sure this change works**
- n/a

**Helpful Docs**
- n/a

**Version for this change**
- This will be release v1.2.0. After I merge this branch to master, I will update the changelog and push a release commit.