### PR TITLE
[STRATCONN-141] Support snake_case properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=1.2.1-SNAPSHOT
+VERSION=1.3.0-SNAPSHOT
 
 POM_ARTIFACT_ID=adobe-analytics
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/ContextDataConfiguration.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/ContextDataConfiguration.java
@@ -1,6 +1,5 @@
 package com.segment.analytics.android.integrations.adobeanalytics;
 
-import com.segment.analytics.Properties;
 import com.segment.analytics.ValueMap;
 import com.segment.analytics.integrations.BasePayload;
 

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/EcommerceAnalytics.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/EcommerceAnalytics.java
@@ -7,7 +7,9 @@ import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.TrackPayload;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -133,14 +135,21 @@ public class EcommerceAnalytics {
       products = new Products(properties.getList("products", Properties.Product.class));
       extraProperties.remove("products");
     } else {
+      List<String> propertiesToRemove = new LinkedList<>();
+      propertiesToRemove.add("category");
+      propertiesToRemove.add("quantity");
+      propertiesToRemove.add("price");
       products = new Products(properties);
 
       String idKey = productIdentifier;
       if (idKey == null || idKey.equals("id")) {
-        idKey = "productId";
+        propertiesToRemove.add("productId");
+        propertiesToRemove.add("product_id");
+      } else {
+        propertiesToRemove.add(idKey);
       }
 
-      for (String key : new String[] {"category", "quantity", "price", idKey}) {
+      for (String key : propertiesToRemove) {
         extraProperties.remove(key);
       }
     }
@@ -152,6 +161,11 @@ public class EcommerceAnalytics {
     if (properties.containsKey("orderId")) {
       contextData.put("purchaseid", properties.getString("orderId"));
       extraProperties.remove("orderId");
+    }
+
+    if (properties.containsKey("order_id")) {
+      contextData.put("purchaseid", properties.getString("order_id"));
+      extraProperties.remove("order_id");
     }
 
     // add all customer-mapped properties to ecommerce context data map
@@ -282,6 +296,11 @@ public class EcommerceAnalytics {
       // Fallback to "productId" as V2 ecommerce spec
       if (id == null || id.trim().length() == 0) {
         id = eventProduct.getString("productId");
+      }
+
+      // Fallback to "product_id" as V2 ecommerce spec
+      if (id == null || id.trim().length() == 0) {
+        id = eventProduct.getString("product_id");
       }
 
       // Fallback to "id" as V1 ecommerce spec

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/PlaybackDelegate.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/PlaybackDelegate.java
@@ -42,12 +42,22 @@ class PlaybackDelegate implements MediaHeartbeat.MediaHeartbeatDelegate {
    *     invocation of this method.
    */
   void createAndUpdateQosObject(Properties properties) {
+    double startupTime = properties.getDouble("startupTime", 0);
+    if (startupTime == 0) {
+      startupTime = properties.getDouble("startup_time", 0);
+    }
+
+    long droppedFrames = properties.getLong("droppedFrames", 0);
+    if (droppedFrames == 0) {
+      droppedFrames = properties.getLong("dropped_frames", 0);
+    }
+
     qosData =
         MediaHeartbeat.createQoSObject(
             properties.getLong("bitrate", 0),
-            properties.getDouble("startupTime", 0),
+            startupTime,
             properties.getDouble("fps", 0),
-            properties.getLong("droppedFrames", 0));
+            droppedFrames);
   }
 
   /** Adobe invokes this method once every ten seconds to report quality of service data. */


### PR DESCRIPTION
**What does this PR do?**
Allows to use snake_case properties (ie. `contentAssetId` and `content_asset_id`), by default prioritizing camelCase (as it was before).

**Are there breaking changes in this PR?**
No

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
Yes

- [STRATCONN-141](https://segment.atlassian.net/browse/STRATCONN-141)