### PR TITLE
[STRATCONN-273] update trackComplete logic on video events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+1.4.0 / 2020-06-25
+==================
+
+  * [STRATCONN-273] Update trackComplete logic on Video Content Completed and Video Playback Completed events (#74)
+
 1.3.0 / 2020-03-31
 ==================
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.segment.analytics.android.integrations
 
-VERSION=1.3.0-SNAPSHOT
+VERSION=1.4.0-SNAPSHOT
 
 POM_ARTIFACT_ID=adobe-analytics
 POM_PACKAGING=jar

--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/VideoAnalytics.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/VideoAnalytics.java
@@ -315,11 +315,13 @@ class VideoAnalytics {
 
   private void trackVideoContentCompleted() {
     trackAdobeEvent(MediaHeartbeat.Event.ChapterComplete, null, null);
-    heartbeat.trackComplete();
-    logger.verbose("heartbeat.trackComplete();");
   }
 
+  //Upon playback complete, pause playhead, call trackComplete, and end session
   private void trackVideoPlaybackCompleted() {
+    playback.pausePlayhead();
+    heartbeat.trackComplete();
+    logger.verbose("heartbeat.trackComplete();");
     heartbeat.trackSessionEnd();
     logger.verbose("heartbeat.trackSessionEnd();");
   }

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/VideoAnalyticsTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/VideoAnalyticsTest.java
@@ -305,13 +305,14 @@ public class VideoAnalyticsTest {
     startVideoSession();
     sendHeartbeat("Video Content Completed");
     Mockito.verify(heartbeat).trackEvent(MediaHeartbeat.Event.ChapterComplete, null, null);
-    Mockito.verify(heartbeat).trackComplete();
   }
 
   @Test
   public void trackVideoPlaybackComplete() {
     startVideoSession();
     sendHeartbeat("Video Playback Completed");
+    Assert.assertTrue(videoAnalytics.getPlayback().isPaused());
+    Mockito.verify(heartbeat).trackComplete();
     Mockito.verify(heartbeat).trackSessionEnd();
   }
 


### PR DESCRIPTION
**What does this PR do?**
This PR removes `trackComplete` from Video Content Completed events and only calls chapterComplete on these events. It also adds `pausePlayhead` and `trackComplete` to Video Playback Completed events. This is in line with Adobe's documentation and also allows for parity between iOS, a.js, and Android.

**Are there breaking changes in this PR?**
No

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
Test file updated and all unit tests passed:
![Screen Shot 2020-06-24 at 2 18 50 PM](https://user-images.githubusercontent.com/49517136/85629317-7d92b300-b626-11ea-8e3a-edf71a35bbb0.png)

**Is there parity with the server-side/analytics.js integration (if applicable)?**
iOS and a.js integrations are being updated with the same changes.

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**
No

**What are the relevant tickets?**
Relevant JIRA: https://segment.atlassian.net/browse/STRATCONN-273

**Helpful Docs**
_Adobe docs_
Core playback on Android: https://docs.adobe.com/content/help/en/media-analytics/using/sdk-implement/track-av-playback/track-core/track-core-android.html
Chapters on Android: https://docs.adobe.com/content/help/en/media-analytics/using/sdk-implement/track-chapters/track-chapters-android.html

**Version for this change**
TBD