### PR TITLE
map Video Playback Interrupted to trackPause()

### DIFF
--- a/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/VideoAnalytics.java
+++ b/src/main/java/com/segment/analytics/android/integrations/adobeanalytics/VideoAnalytics.java
@@ -383,6 +383,8 @@ class VideoAnalytics {
 
   private void trackVideoPlaybackInterrupted() {
     playback.pausePlayhead();
+    heartbeat.trackPause();
+    logger.verbose("heartbeat.trackPause();");
   }
 
   private void trackVideoQualityUpdated(TrackPayload track) {

--- a/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/VideoAnalyticsTest.java
+++ b/src/test/java/com/segment/analytics/android/integrations/adobeanalytics/VideoAnalyticsTest.java
@@ -526,6 +526,7 @@ public class VideoAnalyticsTest {
     Double first = videoAnalytics.getPlayback().getCurrentPlaybackTime();
     Thread.sleep(2000L);
     Assert.assertEquals(videoAnalytics.getPlayback().getCurrentPlaybackTime(), first, 0.001);
+    Mockito.verify(heartbeat).trackPause();
   }
 
   @Test


### PR DESCRIPTION
map Video Playback Interrupted to trackPause() per Adobe team recommendation

**What does this PR do?**
Adds a new mapping - maps Video Playback Interrupted event to trackPause() Adobe method. 
The mapping was recommended by Adobe team to resolve the following issue: when a user interrupts the video during ad break, Adobe keeps sending "ad: play: live" heartbeats which inflates Ad Time Spent metric in Adobe. 
Calling trackPause() upon video interruption makes Adobe start sending pause heartbeats. The heartbeats are sent until the session elapses (up to 30 min). That is the expected behavior.

**Are there breaking changes in this PR?**
No

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
Yes it was tested: [JIRA ticket link](https://segment.atlassian.net/browse/LIBMOBILE-989)

**Any background context you want to provide?**

**Is there parity with the server-side/analytics.js integration (if applicable)?**
The change is made only on Android, as we're not seeing this issue on iOS. 
On Web we're already calling trackPause() upon video interruption.

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**
No

**What are the relevant tickets?**
No

**Link to CC ticket**
N/A

**List all the tests accounts you have used to make sure this change works**
N/A

**Helpful Docs**
N/A

**Version for this change**
1.4.2